### PR TITLE
remove redundant license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # RobotLog2DB
 
-[![License: Apache
-v2](https://img.shields.io/pypi/l/robotframework.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
-
 ## Table of Contents
 
 -   [Getting Started](#getting-started)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 -   [Usage](#usage)
 -   [Example](#example)
 -   [Contribution](#contribution)
--   [Sourcecode Documentation](#documentation)
+-   [Sourcecode Documentation](#sourcecode-documentation)
 -   [Feedback](#feedback)
 -   [About](#about)
     -   [Maintainers](#maintainers)

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Table of Contents
 -  `Usage <#usage>`__
 -  `Example <#example>`__
 -  `Contribution <#contribution>`__
--  `Sourcecode Documentation <#documentation>`__
+-  `Sourcecode Documentation <#sourcecode-documentation>`__
 -  `Feedback <#feedback>`__
 -  `About <#about>`__
 

--- a/README.rst
+++ b/README.rst
@@ -1,21 +1,5 @@
-.. Copyright 2020-2022 Robert Bosch GmbH
-
-.. Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-.. http://www.apache.org/licenses/LICENSE-2.0
-
-.. Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-
 RobotLog2DB
 ===========
-
-|License: Apache v2|
 
 Table of Contents
 -----------------


### PR DESCRIPTION
Hi Holger,

The redundant license info at header and link at top of README file has been removed.

Thank you,
Ngoan